### PR TITLE
Update clipboard-helper.js

### DIFF
--- a/clipboard-helper.js
+++ b/clipboard-helper.js
@@ -8,7 +8,7 @@ function copyToClipboard(text) {
 
     // Overwrite the clipboard content.
     event.preventDefault();
-    event.clipboardData.setData("text/plain", text);
+    event.clipboardData.setData("text/html", text);
   }
   document.addEventListener("copy", oncopy, true);
 


### PR DESCRIPTION
In some HTML editor (ex. Blogger.com), when copying with text/html, paste it as the valid anchor tag.In both Create Link and Make Link, it was copied in text/html.
Would you please change text/plain to text/html in Format Link?