### PR TITLE
Fix using default options when no settings in storage

### DIFF
--- a/common.js
+++ b/common.js
@@ -24,7 +24,7 @@ const DEFAULT_OPTIONS = {
 };
 
 async function gettingOptions() {
-  const options = await browser.storage.sync.get(null);
+  let options = await browser.storage.sync.get(null);
   if (Object.keys(options).length === 0) {
     options = DEFAULT_OPTIONS;
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Format Link",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "manifest_version": 2,
   "description": "Format a link and copy it to the clipboard.",
   "icons": {


### PR DESCRIPTION
As commented at https://github.com/hnakamur/FormatLink-Firefox/issues/25#issuecomment-541428119
